### PR TITLE
[SRVC-4486] Fix source/pointer for unexpected_field error

### DIFF
--- a/lib/open_api_spex/cast/object.ex
+++ b/lib/open_api_spex/cast/object.ex
@@ -34,6 +34,7 @@ defmodule OpenApiSpex.Cast.Object do
       :ok
     else
       [name | _] = extra_keys
+      ctx = %{ctx | path: [name | ctx.path]}
       Cast.error(ctx, {:unexpected_field, name})
     end
   end

--- a/test/cast/object_test.exs
+++ b/test/cast/object_test.exs
@@ -45,6 +45,9 @@ defmodule OpenApiSpex.ObjectTest do
       assert cast(value: %{}, schema: schema) == {:ok, %{}}
       assert {:error, [error]} = cast(value: %{"unknown" => "hello"}, schema: schema)
       assert %Error{} = error
+      assert error.reason == :unexpected_field
+      assert error.name == "unknown"
+      assert error.path == ["unknown"]
     end
 
     test "with schema properties set, given known input property" do


### PR DESCRIPTION
For the `:unexpected_field` error, the source/pointer path was empty. It should container the path to the offending field.