### PR TITLE
[SRVC-4463] validate query params

### DIFF
--- a/lib/open_api_spex/cast.ex
+++ b/lib/open_api_spex/cast.ex
@@ -1,6 +1,17 @@
 defmodule OpenApiSpex.Cast do
-  alias OpenApiSpex.Reference
+  alias OpenApiSpex.{Reference, Schema}
   alias OpenApiSpex.Cast.{Array, Error, Object, Primitive, String}
+
+  @type schema_or_reference :: Schema.t() | Reference.t()
+  @type t :: %__MODULE__{
+          value: term(),
+          schema: schema_or_reference | nil,
+          schemas: map(),
+          path: [atom() | String.t() | integer()],
+          key: atom() | nil,
+          index: integer,
+          errors: [Error.t()]
+        }
 
   defstruct value: nil,
             schema: nil,
@@ -10,10 +21,13 @@ defmodule OpenApiSpex.Cast do
             index: 0,
             errors: []
 
+  @spec cast(schema_or_reference | nil, term(), map()) :: {:ok, term()} | {:error, [Error.t()]}
   def cast(schema, value, schemas) do
     ctx = %__MODULE__{schema: schema, value: value, schemas: schemas}
     cast(ctx)
   end
+
+  @spec cast(t()) :: {:ok, term()} | {:error, [Error.t()]}
 
   # nil schema
   def cast(%__MODULE__{value: value, schema: nil}),
@@ -36,7 +50,7 @@ defmodule OpenApiSpex.Cast do
 
   # Enum
   def cast(%__MODULE__{schema: %{enum: []}} = ctx) do
-    cast(%{ctx | enum: nil})
+    cast(%{ctx | schema: %{ctx.schema | enum: nil}})
   end
 
   # Enum

--- a/lib/open_api_spex/cast/error.ex
+++ b/lib/open_api_spex/cast/error.ex
@@ -118,7 +118,14 @@ defmodule OpenApiSpex.Cast.Error do
   end
 
   def path_to_string(%{path: path} = _error) do
-    "/" <> (path |> Enum.map(&to_string/1) |> Path.join())
+    path =
+      if path == [] do
+        ""
+      else
+        path |> Enum.map(&to_string/1) |> Path.join()
+      end
+
+    "/" <> path
   end
 
   defp add_context_fields(error, ctx) do

--- a/lib/open_api_spex/cast/object.ex
+++ b/lib/open_api_spex/cast/object.ex
@@ -34,6 +34,7 @@ defmodule OpenApiSpex.Cast.Object do
       :ok
     else
       [name | _] = extra_keys
+      ctx = %{ctx | path: [name | ctx.path]}
       Cast.error(ctx, {:unexpected_field, name})
     end
   end

--- a/lib/open_api_spex/cast_parameters.ex
+++ b/lib/open_api_spex/cast_parameters.ex
@@ -11,12 +11,12 @@ defmodule OpenApiSpex.CastParameters do
     # Convert parameters to an object schema, then delegate to `Cast.Object.cast/1`
 
     properties =
-      (operation.parameters || [])
+      operation.parameters
       |> Enum.map(fn parameter -> {parameter.name, Parameter.schema(parameter)} end)
       |> Map.new()
 
     required =
-      (operation.parameters || [])
+      operation.parameters
       |> Enum.filter(& &1.required)
       |> Enum.map(& &1.name)
 

--- a/lib/open_api_spex/cast_parameters.ex
+++ b/lib/open_api_spex/cast_parameters.ex
@@ -1,0 +1,59 @@
+defmodule OpenApiSpex.CastParameters do
+  @moduledoc false
+  alias OpenApiSpex.{Cast, Operation, Parameter, Schema}
+  alias OpenApiSpex.Cast.Error
+  alias Plug.Conn
+
+  @spec cast(Plug.Conn.t(), Operation.t(), Schema.schemas()) ::
+          {:error, [Error.t()]} | {:ok, Conn.t()}
+  def cast(conn, operation, schemas) do
+    parameters =
+      Enum.filter(operation.parameters || [], fn p ->
+        Map.has_key?(conn.params, Atom.to_string(p.name))
+      end)
+
+    with :ok <- check_query_params_defined(conn, operation.parameters),
+         {:ok, parameter_values} <- cast_known_parameters(parameters, conn.params, schemas) do
+      {:ok, %{conn | params: parameter_values}}
+    end
+  end
+
+  ## Private functions
+
+  defp check_query_params_defined(%Conn{}, nil = _defined_params) do
+    :ok
+  end
+
+  defp check_query_params_defined(%Conn{} = conn, defined_params)
+       when is_list(defined_params) do
+    defined_query_params =
+      for param <- defined_params,
+          param.in == :query,
+          into: MapSet.new(),
+          do: to_string(param.name)
+
+    case validate_parameter_keys(Map.keys(conn.query_params), defined_query_params) do
+      {:error, name} -> {:error, [%Error{reason: :unexpected_field, name: name}]}
+      :ok -> :ok
+    end
+  end
+
+  defp validate_parameter_keys([], _defined_params), do: :ok
+
+  defp validate_parameter_keys([name | params], defined_params) do
+    case MapSet.member?(defined_params, name) do
+      false -> {:error, name}
+      _ -> validate_parameter_keys(params, defined_params)
+    end
+  end
+
+  defp cast_known_parameters([], _params, _schemas), do: {:ok, %{}}
+
+  defp cast_known_parameters([p | rest], params = %{}, schemas) do
+    with {:ok, cast_val} <-
+           Cast.cast(Parameter.schema(p), params[Atom.to_string(p.name)], schemas),
+         {:ok, cast_tail} <- cast_known_parameters(rest, params, schemas) do
+      {:ok, Map.put_new(cast_tail, p.name, cast_val)}
+    end
+  end
+end

--- a/lib/open_api_spex/cast_parameters.ex
+++ b/lib/open_api_spex/cast_parameters.ex
@@ -26,7 +26,9 @@ defmodule OpenApiSpex.CastParameters do
       required: required
     }
 
-    ctx = %Cast{value: conn.params, schema: object_schema, schemas: schemas}
+    params = Map.merge(conn.path_params, conn.query_params)
+
+    ctx = %Cast{value: params, schema: object_schema, schemas: schemas}
 
     with {:ok, params} <- Object.cast(ctx) do
       {:ok, %{conn | params: params}}

--- a/lib/open_api_spex/cast_parameters.ex
+++ b/lib/open_api_spex/cast_parameters.ex
@@ -1,59 +1,35 @@
 defmodule OpenApiSpex.CastParameters do
   @moduledoc false
   alias OpenApiSpex.{Cast, Operation, Parameter, Schema}
-  alias OpenApiSpex.Cast.Error
+  alias OpenApiSpex.Cast.{Error, Object}
   alias Plug.Conn
 
   @spec cast(Plug.Conn.t(), Operation.t(), Schema.schemas()) ::
           {:error, [Error.t()]} | {:ok, Conn.t()}
   def cast(conn, operation, schemas) do
-    parameters =
-      Enum.filter(operation.parameters || [], fn p ->
-        Map.has_key?(conn.params, Atom.to_string(p.name))
-      end)
+    # Taken together as a set, operation parameters are similar to an object schema type.
+    # Convert parameters to an object schema, then delegate to `Cast.Object.cast/1`
 
-    with :ok <- check_query_params_defined(conn, operation.parameters),
-         {:ok, parameter_values} <- cast_known_parameters(parameters, conn.params, schemas) do
-      {:ok, %{conn | params: parameter_values}}
-    end
-  end
+    properties =
+      (operation.parameters || [])
+      |> Enum.map(fn parameter -> {parameter.name, Parameter.schema(parameter)} end)
+      |> Map.new()
 
-  ## Private functions
+    required =
+      (operation.parameters || [])
+      |> Enum.filter(& &1.required)
+      |> Enum.map(& &1.name)
 
-  defp check_query_params_defined(%Conn{}, nil = _defined_params) do
-    :ok
-  end
+    object_schema = %Schema{
+      type: :object,
+      properties: properties,
+      required: required
+    }
 
-  defp check_query_params_defined(%Conn{} = conn, defined_params)
-       when is_list(defined_params) do
-    defined_query_params =
-      for param <- defined_params,
-          param.in == :query,
-          into: MapSet.new(),
-          do: to_string(param.name)
+    ctx = %Cast{value: conn.params, schema: object_schema, schemas: schemas}
 
-    case validate_parameter_keys(Map.keys(conn.query_params), defined_query_params) do
-      {:error, name} -> {:error, [%Error{reason: :unexpected_field, name: name}]}
-      :ok -> :ok
-    end
-  end
-
-  defp validate_parameter_keys([], _defined_params), do: :ok
-
-  defp validate_parameter_keys([name | params], defined_params) do
-    case MapSet.member?(defined_params, name) do
-      false -> {:error, name}
-      _ -> validate_parameter_keys(params, defined_params)
-    end
-  end
-
-  defp cast_known_parameters([], _params, _schemas), do: {:ok, %{}}
-
-  defp cast_known_parameters([p | rest], params = %{}, schemas) do
-    with {:ok, cast_val} <-
-           Cast.cast(Parameter.schema(p), params[Atom.to_string(p.name)], schemas),
-         {:ok, cast_tail} <- cast_known_parameters(rest, params, schemas) do
-      {:ok, Map.put_new(cast_tail, p.name, cast_val)}
+    with {:ok, params} <- Object.cast(ctx) do
+      {:ok, %{conn | params: params}}
     end
   end
 end

--- a/lib/open_api_spex/operation.ex
+++ b/lib/open_api_spex/operation.ex
@@ -46,7 +46,7 @@ defmodule OpenApiSpex.Operation do
           requestBody: RequestBody.t() | Reference.t() | nil,
           responses: Responses.t(),
           callbacks: %{String.t() => Callback.t() | Reference.t()},
-          deprecated: boolean | nil,
+          deprecated: boolean,
           security: [SecurityRequirement.t()],
           servers: [Server.t()]
         }

--- a/lib/open_api_spex/operation.ex
+++ b/lib/open_api_spex/operation.ex
@@ -37,19 +37,19 @@ defmodule OpenApiSpex.Operation do
   Describes a single API operation on a path.
   """
   @type t :: %__MODULE__{
-    tags: [String.t] | nil,
-    summary: String.t | nil,
-    description: String.t | nil,
-    externalDocs: ExternalDocumentation.t | nil,
-    operationId: String.t | nil,
-    parameters: [Parameter.t | Reference.t] | nil,
-    requestBody: RequestBody.t | Reference.t | nil,
-    responses: Responses.t,
-    callbacks: %{String.t => Callback.t | Reference.t} | nil,
-    deprecated: boolean | nil,
-    security: [SecurityRequirement.t] | nil,
-    servers: [Server.t] | nil
-  }
+          tags: [String.t()],
+          summary: String.t() | nil,
+          description: String.t() | nil,
+          externalDocs: ExternalDocumentation.t() | nil,
+          operationId: String.t() | nil,
+          parameters: [Parameter.t() | Reference.t()],
+          requestBody: RequestBody.t() | Reference.t() | nil,
+          responses: Responses.t(),
+          callbacks: %{String.t() => Callback.t() | Reference.t()},
+          deprecated: boolean | nil,
+          security: [SecurityRequirement.t()],
+          servers: [Server.t()]
+        }
 
   @doc """
   Constructs an Operation struct from the plug and opts specified in the given route

--- a/lib/open_api_spex/operation.ex
+++ b/lib/open_api_spex/operation.ex
@@ -18,20 +18,18 @@ defmodule OpenApiSpex.Operation do
   }
 
   @enforce_keys :responses
-  defstruct [
-    :tags,
-    :summary,
-    :description,
-    :externalDocs,
-    :operationId,
-    :parameters,
-    :requestBody,
-    :responses,
-    :callbacks,
-    :deprecated,
-    :security,
-    :servers
-  ]
+  defstruct tags: [],
+            summary: nil,
+            description: nil,
+            externalDocs: nil,
+            operationId: nil,
+            parameters: [],
+            requestBody: nil,
+            responses: nil,
+            callbacks: %{},
+            deprecated: false,
+            security: [],
+            servers: []
 
   @typedoc """
   [Operation Object](https://swagger.io/specification/#operationObject)

--- a/lib/open_api_spex/operation2.ex
+++ b/lib/open_api_spex/operation2.ex
@@ -33,11 +33,7 @@ defmodule OpenApiSpex.Operation2 do
       end)
 
     with :ok <- check_query_params_defined(conn, operation.parameters),
-         {:ok, parameter_values} <- cast_parameters(parameters, conn.params, schemas),
-         conn = %{conn | params: parameter_values},
-         parameters =
-           Enum.filter(operation.parameters || [], &Map.has_key?(conn.params, &1.name)),
-         :ok <- validate_parameter_schemas(parameters, conn.params, schemas) do
+         {:ok, parameter_values} <- cast_parameters(parameters, conn.params, schemas) do
       {:ok, %{conn | params: parameter_values}}
     end
   end
@@ -76,16 +72,6 @@ defmodule OpenApiSpex.Operation2 do
            Cast.cast(Parameter.schema(p), params[Atom.to_string(p.name)], schemas),
          {:ok, cast_tail} <- cast_parameters(rest, params, schemas) do
       {:ok, Map.put_new(cast_tail, p.name, cast_val)}
-    end
-  end
-
-  defp validate_parameter_schemas([], %{} = _params, _schemas), do: :ok
-
-  defp validate_parameter_schemas([p | rest], %{} = params, schemas) do
-    {:ok, parameter_value} = Map.fetch(params, p.name)
-
-    with {:ok, _value} <- Cast.cast(Parameter.schema(p), parameter_value, schemas) do
-      validate_parameter_schemas(rest, params, schemas)
     end
   end
 

--- a/lib/open_api_spex/operation2.ex
+++ b/lib/open_api_spex/operation2.ex
@@ -10,15 +10,21 @@ defmodule OpenApiSpex.Operation2 do
     Schema
   }
 
+  alias Plug.Conn
+
   alias OpenApiSpex.Cast.Error
 
-  def cast(operation = %Operation{}, conn = %Plug.Conn{}, content_type, schemas) do
+  @spec cast(Operation.t(), Conn.t(), String.t() | nil, Schema.schemas()) ::
+          {:error, [Error.t()]} | {:ok, Conn.t()}
+  def cast(operation = %Operation{}, conn = %Conn{}, content_type, schemas) do
     with {:ok, conn} <- cast_query_parameters(conn, operation, schemas),
          {:ok, body} <-
            cast_request_body(operation.requestBody, conn.body_params, content_type, schemas) do
       {:ok, %{conn | body_params: body}}
     end
   end
+
+  ## Private functions
 
   defp cast_query_parameters(conn, operation, schemas) do
     parameters =
@@ -36,12 +42,11 @@ defmodule OpenApiSpex.Operation2 do
     end
   end
 
-  @spec check_query_params_defined(Conn.t(), list | nil) :: :ok | {:error, String.t()}
-  defp check_query_params_defined(%Plug.Conn{}, nil = _defined_params) do
+  defp check_query_params_defined(%Conn{}, nil = _defined_params) do
     :ok
   end
 
-  defp check_query_params_defined(%Plug.Conn{} = conn, defined_params)
+  defp check_query_params_defined(%Conn{} = conn, defined_params)
        when is_list(defined_params) do
     defined_query_params =
       for param <- defined_params,
@@ -55,7 +60,6 @@ defmodule OpenApiSpex.Operation2 do
     end
   end
 
-  @spec validate_parameter_keys([String.t()], MapSet.t()) :: {:error, String.t()} | :ok
   defp validate_parameter_keys([], _defined_params), do: :ok
 
   defp validate_parameter_keys([name | params], defined_params) do
@@ -65,8 +69,6 @@ defmodule OpenApiSpex.Operation2 do
     end
   end
 
-  @spec cast_parameters([Parameter.t()], map, Schema.schemas()) ::
-          {:ok, map} | {:error, [Error.t()]}
   defp cast_parameters([], _params, _schemas), do: {:ok, %{}}
 
   defp cast_parameters([p | rest], params = %{}, schemas) do
@@ -77,17 +79,6 @@ defmodule OpenApiSpex.Operation2 do
     end
   end
 
-  @spec cast_request_body(RequestBody.t() | nil, map, String.t() | nil, Schema.schemas()) ::
-          {:ok, map} | {:error, String.t()}
-  defp cast_request_body(nil, _, _, _), do: {:ok, %{}}
-
-  defp cast_request_body(%RequestBody{content: content}, params, content_type, schemas) do
-    schema = content[content_type].schema
-    Cast.cast(schema, params, schemas)
-  end
-
-  @spec validate_parameter_schemas([Parameter.t()], map, %{String.t() => Schema.t()}) ::
-          :ok | {:error, String.t()}
   defp validate_parameter_schemas([], %{} = _params, _schemas), do: :ok
 
   defp validate_parameter_schemas([p | rest], %{} = params, schemas) do
@@ -96,5 +87,12 @@ defmodule OpenApiSpex.Operation2 do
     with {:ok, _value} <- Cast.cast(Parameter.schema(p), parameter_value, schemas) do
       validate_parameter_schemas(rest, params, schemas)
     end
+  end
+
+  defp cast_request_body(nil, _, _, _), do: {:ok, %{}}
+
+  defp cast_request_body(%RequestBody{content: content}, params, content_type, schemas) do
+    schema = content[content_type].schema
+    Cast.cast(schema, params, schemas)
   end
 end

--- a/lib/open_api_spex/operation2.ex
+++ b/lib/open_api_spex/operation2.ex
@@ -69,9 +69,8 @@ defmodule OpenApiSpex.Operation2 do
     end
   end
 
-  @spec cast_request_body(RequestBody.t() | nil, map, String.t() | nil, %{
-          String.t() => Schema.t()
-        }) :: {:ok, map} | {:error, String.t()}
+  @spec cast_request_body(RequestBody.t() | nil, map, String.t() | nil, Schema.schemas()) ::
+          {:ok, map} | {:error, String.t()}
   defp cast_request_body(nil, _, _, _), do: {:ok, %{}}
 
   defp cast_request_body(%RequestBody{content: content}, params, content_type, schemas) do

--- a/lib/open_api_spex/operation2.ex
+++ b/lib/open_api_spex/operation2.ex
@@ -4,8 +4,8 @@ defmodule OpenApiSpex.Operation2 do
   """
   alias OpenApiSpex.{
     Cast,
+    CastParameters,
     Operation,
-    Parameter,
     RequestBody,
     Schema
   }
@@ -26,52 +26,7 @@ defmodule OpenApiSpex.Operation2 do
   ## Private functions
 
   defp cast_parameters(conn, operation, schemas) do
-    parameters =
-      Enum.filter(operation.parameters || [], fn p ->
-        Map.has_key?(conn.params, Atom.to_string(p.name))
-      end)
-
-    with :ok <- check_query_params_defined(conn, operation.parameters),
-         {:ok, parameter_values} <- cast_known_parameters(parameters, conn.params, schemas) do
-      {:ok, %{conn | params: parameter_values}}
-    end
-  end
-
-  defp check_query_params_defined(%Conn{}, nil = _defined_params) do
-    :ok
-  end
-
-  defp check_query_params_defined(%Conn{} = conn, defined_params)
-       when is_list(defined_params) do
-    defined_query_params =
-      for param <- defined_params,
-          param.in == :query,
-          into: MapSet.new(),
-          do: to_string(param.name)
-
-    case validate_parameter_keys(Map.keys(conn.query_params), defined_query_params) do
-      {:error, name} -> {:error, [%Error{reason: :unexpected_field, name: name}]}
-      :ok -> :ok
-    end
-  end
-
-  defp validate_parameter_keys([], _defined_params), do: :ok
-
-  defp validate_parameter_keys([name | params], defined_params) do
-    case MapSet.member?(defined_params, name) do
-      false -> {:error, name}
-      _ -> validate_parameter_keys(params, defined_params)
-    end
-  end
-
-  defp cast_known_parameters([], _params, _schemas), do: {:ok, %{}}
-
-  defp cast_known_parameters([p | rest], params = %{}, schemas) do
-    with {:ok, cast_val} <-
-           Cast.cast(Parameter.schema(p), params[Atom.to_string(p.name)], schemas),
-         {:ok, cast_tail} <- cast_known_parameters(rest, params, schemas) do
-      {:ok, Map.put_new(cast_tail, p.name, cast_val)}
-    end
+    CastParameters.cast(conn, operation, schemas)
   end
 
   defp cast_request_body(nil, _, _, _), do: {:ok, %{}}

--- a/lib/open_api_spex/schema.ex
+++ b/lib/open_api_spex/schema.ex
@@ -243,6 +243,9 @@ defmodule OpenApiSpex.Schema do
   """
   @type data_type :: :string | :number | :integer | :boolean | :array | :object
 
+  @typedoc """
+  Global schemas lookup by name.
+  """
   @type schemas :: %{String.t() => t()}
 
   @doc """

--- a/lib/open_api_spex/schema.ex
+++ b/lib/open_api_spex/schema.ex
@@ -243,6 +243,8 @@ defmodule OpenApiSpex.Schema do
   """
   @type data_type :: :string | :number | :integer | :boolean | :array | :object
 
+  @type schemas :: %{String.t() => t()}
+
   @doc """
   Cast a simple value to the elixir type defined by a schema.
 

--- a/test/cast/error_test.exs
+++ b/test/cast/error_test.exs
@@ -5,7 +5,7 @@ defmodule OpenApiSpex.Cast.ErrorTest do
   describe "path_to_string/1" do
     test "with empty path" do
       error = %Error{path: []}
-      Error.path_to_string(error)
+      assert Error.path_to_string(error) == "/"
     end
   end
 end

--- a/test/cast/error_test.exs
+++ b/test/cast/error_test.exs
@@ -1,0 +1,11 @@
+defmodule OpenApiSpex.Cast.ErrorTest do
+  use ExUnit.Case
+  alias OpenApiSpex.Cast.Error
+
+  describe "path_to_string/1" do
+    test "with empty path" do
+      error = %Error{path: []}
+      Error.path_to_string(error)
+    end
+  end
+end

--- a/test/cast/object_test.exs
+++ b/test/cast/object_test.exs
@@ -57,6 +57,18 @@ defmodule OpenApiSpex.ObjectTest do
       assert cast(value: %{"age" => "hello"}, schema: schema) == {:ok, %{age: "hello"}}
     end
 
+    test "unexpected field" do
+      schema = %Schema{
+        type: :object,
+        properties: %{}
+      }
+
+      assert {:error, [error]} = cast(value: %{foo: "foo"}, schema: schema)
+      assert %Error{} = error
+      assert error.reason == :unexpected_field
+      assert error.path == ["foo"]
+    end
+
     test "required fields" do
       schema = %Schema{
         type: :object,

--- a/test/operation2_test.exs
+++ b/test/operation2_test.exs
@@ -112,7 +112,7 @@ defmodule OpenApiSpex.Operation2Test do
       assert error.reason == :invalid_type
     end
 
-    test "cast query params" do
+    test "validate param name is defined" do
       query_params = %{"unknown" => "asdf"}
 
       conn =

--- a/test/operation2_test.exs
+++ b/test/operation2_test.exs
@@ -1,0 +1,90 @@
+defmodule OpenApiSpex.Operation2Test do
+  use ExUnit.Case
+  alias OpenApiSpex.{Operation, Operation2, Schema}
+
+  defmodule SchemaFixtures do
+    @user %Schema{
+      type: :object,
+      properties: %{
+        user: %Schema{
+          type: :object,
+          properties: %{
+            email: %Schema{type: :string}
+          }
+        }
+      }
+    }
+    @schemas %{"User" => @user}
+
+    def user, do: @user
+    def schemas, do: @schemas
+  end
+
+  defmodule OperationFixtures do
+    @create_user %Operation{
+      operationId: "UserController.create",
+      requestBody:
+        Operation.request_body("request body", "application/json", SchemaFixtures.user(),
+          required: true
+        ),
+      responses: %{
+        200 => Operation.response("User", "application/json", SchemaFixtures.user())
+      }
+    }
+
+    def create_user, do: @create_user
+  end
+
+  defmodule SpecModule do
+    def spec do
+      paths = %{
+        "/users" => %{
+          "post" => OperationFixtures.create_user()
+        }
+      }
+
+      %OpenApiSpex.OpenApi{
+        info: nil,
+        paths: paths,
+        components: %{
+          schemas: SchemaFixtures.schemas()
+        }
+      }
+    end
+  end
+
+  defmodule RenderError do
+    def init(_) do
+      nil
+    end
+
+    def call(_conn, _errors) do
+      raise "should not have errors"
+    end
+  end
+
+  describe "cast/4" do
+    test "cast request body" do
+      conn = create_conn(%{"user" => %{"email" => "foo@bar.com"}})
+
+      assert {:ok, value} =
+               Operation2.cast(
+                 OperationFixtures.create_user(),
+                 conn,
+                 "application/json",
+                 SchemaFixtures.schemas()
+               )
+
+      assert %Plug.Conn{} = value
+    end
+
+    # TODO Verify query params are casted
+
+    defp create_conn(body_params) do
+      :post
+      |> Plug.Test.conn("/api/users")
+      |> Plug.Conn.put_req_header("content-type", "application/json")
+      |> Map.put(:body_params, body_params)
+    end
+  end
+end


### PR DESCRIPTION
- When validating parameters (either path or query), return `{:error, [Error.t]}` for errors instead of `{:error, String.t}`.
- Implement `required` validation for parameters.
- Deduplicate logic between parameter casting and object casting

```
$ mix test
............................................................................
16:13:22.879 [debug] OpenApiSpexTest.CustomErrorUserController halted in OpenApiSpex.Plug.Cast.call/2
...
16:13:22.896 [debug] OpenApiSpexTest.CustomErrorUserController halted in OpenApiSpex.Plug.Cast.call/2
.
16:13:22.897 [debug] OpenApiSpexTest.UserController halted in OpenApiSpex.Plug.Cast.call/2
..
16:13:22.902 [debug] OpenApiSpexTest.UserController halted in OpenApiSpex.Plug.Cast.call/2
...............
16:13:22.908 [debug] OpenApiSpexTest.UserController halted in OpenApiSpex.Plug.Validate.call/2
..

Finished in 0.7 seconds
6 doctests, 93 tests, 0 failures
```