### PR TITLE
Remove defaults for security and servers on operation

### DIFF
--- a/lib/open_api_spex/operation.ex
+++ b/lib/open_api_spex/operation.ex
@@ -28,8 +28,8 @@ defmodule OpenApiSpex.Operation do
             responses: nil,
             callbacks: %{},
             deprecated: false,
-            security: [],
-            servers: []
+            security: nil,
+            servers: nil
 
   @typedoc """
   [Operation Object](https://swagger.io/specification/#operationObject)


### PR DESCRIPTION
The presence of `security` and `servers` properties at the operation level overrides top-level and path declarations. Setting default values of `[]` causes these properties to be generated in the swagger doc, which in turn breaks swagger-ui when top-level values have been set. Setting values other than nil on the `Operation` struct should therefore be opt-in.