### PR TITLE
SRVC-5247 Convert spec cache to macro

### DIFF
--- a/lib/open_api_spex/plug/put_api_spec.ex
+++ b/lib/open_api_spex/plug/put_api_spec.ex
@@ -9,20 +9,17 @@ defmodule OpenApiSpex.Plug.PutApiSpec do
       plug OpenApiSpex.Plug.PutApiSpec, module: MyAppWeb.ApiSpec
   """
   @behaviour Plug
+  @before_compile __MODULE__.Cache
 
   @impl Plug
   def init([module: _spec_module] = opts) do
-    if function_exported?(:persistent_term, :info, 0) do
-      {opts[:module], :term}
-    else
-      {opts[:module], :env}
-    end
+   opts[:module]
   end
 
   @impl Plug
-  def call(conn, {spec_module, storage}) do
+  def call(conn, spec_module) do
     {spec, operation_lookup} =
-      fetch_spec(spec_module, storage)
+      fetch_spec(spec_module)
 
     private_data =
       conn
@@ -51,33 +48,43 @@ defmodule OpenApiSpex.Plug.PutApiSpec do
     |> Enum.into(%{})
   end
 
-  defp fetch_spec(spec_module, :term) do
-    try do
-      :persistent_term.get(spec_module)
-    rescue
-      ArgumentError ->
-        term_not_found()
-        spec = build_spec(spec_module)
-        :ok = :persistent_term.put(spec_module, spec)
-        spec
-    end
-  end
+  defmodule Cache do
+    defmacro __before_compile__(_env) do
+      if function_exported?(:persistent_term, :info, 0) do
+        quote do
+          def fetch_spec(spec_module) do
+            try do
+              :persistent_term.get(spec_module)
+            rescue
+              ArgumentError ->
+                term_not_found()
+                spec = build_spec(spec_module)
+                :ok = :persistent_term.put(spec_module, spec)
+                spec
+            end
+          end
 
-  defp fetch_spec(spec_module, :env) do
-    case Application.get_env(:open_api_spex, spec_module) do
-      nil ->
-        spec = build_spec(spec_module)
-        Application.put_env(:open_api_spex, spec_module, spec)
-        spec
-      spec -> spec
-    end
-  end
-
-  defp term_not_found do
-    if Application.get_env(:open_api_spex, :persistent_term_warn, false) do
-      IO.warn("Warning: the OpenApiSpec spec was deleted from persistent terms. This can cause serious issues.")
-    else
-      Application.put_env(:open_api_spex, :persistent_term, true)
+          defp term_not_found do
+            if Application.get_env(:open_api_spex, :persistent_term_warn, false) do
+              IO.warn("Warning: the OpenApiSpec spec was deleted from persistent terms. This can cause serious issues.")
+            else
+              Application.put_env(:open_api_spex, :persistent_term, true)
+            end
+          end
+        end
+      else
+        quote do
+          def fetch_spec(spec_module) do
+            case Application.get_env(:open_api_spex, spec_module) do
+              nil ->
+                spec = build_spec(spec_module)
+                Application.put_env(:open_api_spex, spec_module, spec)
+                spec
+              spec -> spec
+            end
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
The check for availability of persistent_term causes a compilation warning when it isn't available. Moving this check and outputting different code in a macro before compilation should avoid that scenario.